### PR TITLE
Fix S3 Bucket ACL conflict with BucketOwnerEnforced

### DIFF
--- a/deployment/stack-set-template.yaml
+++ b/deployment/stack-set-template.yaml
@@ -1388,7 +1388,6 @@ Resources:
         - Key: solution-id-SO0126
           Value: !Sub ${StackSetConstantsCustomResource.ParentStackName}-${PrimaryRegion}
       BucketName: !Sub ${StackSetConstantsCustomResource.UserImportJobMappingFileBucketPrefix}-${AWS::Region}-logs
-      AccessControl: LogDeliveryWrite
       PublicAccessBlockConfiguration:
         BlockPublicAcls: True
         BlockPublicPolicy: True


### PR DESCRIPTION
We received this error when deploying this solution:

> ResourceLogicalId:UserImportJobMappingFilesLogsBucket, ResourceType:AWS::S3::Bucket, ResourceStatusReason:Bucket cannot have ACLs set with ObjectOwnership's BucketOwnerEnforced setting (Service: Amazon S3; Status Code: 400; Error Code: InvalidBucketAclWithObjectOwnership; Request ID: 55BAZN6ED158H9A0; S3 Extended Request ID: Xyuo3mSIU9QcRheNg96VLQLZrB8u333eN629//mAEZ+AVRDP7UfBh4KTWq2luwt0AJPInIl/C8BjjvyGi4OKuA==; Proxy: null).

This change to S3's behavior caused this bug: https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
