### PR TITLE
Enable deletion protection on BackupTable

### DIFF
--- a/deployment/cognito-user-profiles-export-reference-architecture.yaml
+++ b/deployment/cognito-user-profiles-export-reference-architecture.yaml
@@ -77,6 +77,7 @@ Resources:
     Type: AWS::DynamoDB::Table
     DeletionPolicy: Retain
     Properties:
+      DeletionProtectionEnabled: True
       BillingMode: PAY_PER_REQUEST
       StreamSpecification:
         StreamViewType: NEW_AND_OLD_IMAGES


### PR DESCRIPTION
*Description of changes:* This enable the deletion protection on the backup table. This prevent from any accidental deletion.
This is considered as a fail when using the cfn-lint command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
